### PR TITLE
Dialogue UI: Add "Select Item" option

### DIFF
--- a/Assets/Dialogue/DialogueCanvas.prefab
+++ b/Assets/Dialogue/DialogueCanvas.prefab
@@ -1937,7 +1937,7 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 2494340953283904617}
+      - m_Target: {fileID: 8749460222905302390}
         m_TargetAssemblyTypeName: DialogueOptionUI, Assembly-CSharp
         m_MethodName: OptionChosen
         m_Mode: 1

--- a/Assets/Dialogue/DialogueManager.cs
+++ b/Assets/Dialogue/DialogueManager.cs
@@ -38,7 +38,10 @@ public class DialogueManager : MonoBehaviour
 
     public float lastKeyPress = -1.0f;
     public const float KEY_PRESS_TIME_DELTA = 0.3f;  // seconds
+    private bool currentSentenceHasItemOption = false;
     private const string DIALOGUE_LOCK_TAG = "DialogueManager";
+    private Button firstActionBoxButton = null;
+    private Button itemActionBoxButton = null;
 
     public static void Log(string msg) {
         #if DEBUG_DIALOGUE_SYSTEM
@@ -235,6 +238,10 @@ public class DialogueManager : MonoBehaviour
             }
         }
 
+        firstActionBoxButton = null;
+        itemActionBoxButton = null;
+        currentSentenceHasItemOption = false;
+
         if (availableOptions.Count != 0) {
             canBeAdvancedByKeypress = false;
 
@@ -254,6 +261,7 @@ public class DialogueManager : MonoBehaviour
                 Debug.Log("Sentence has an ItemOption");
                 shownOptions.Add(new OpenInventoryOption());
             }
+            currentSentenceHasItemOption = hasItemOption;
 
             int n = Mathf.Min(shownOptions.Count, actionBoxes.Count);
             for (int i = 0; i < n; ++i) {
@@ -280,10 +288,11 @@ public class DialogueManager : MonoBehaviour
                     actionBox.button.interactable = true;
                 }
                 if (option is OpenInventoryOption) {
-                   // actionBox.button.onClick = () => {};
+                   itemActionBoxButton = actionBox.button;
                 }
                 if (i == 0) {
-                    StartCoroutine(UIUtility.SelectButtonLater(actionBox.button));
+                    firstActionBoxButton = actionBox.button;
+                    SelectFirstActionBox();
                 }
             }
             foreach (Animator uiAnimator in uiAnimators) {
@@ -351,12 +360,27 @@ public class DialogueManager : MonoBehaviour
         return activeDialogue != null;
     }
 
+    public bool CurrentSentenceHasItemOption() {
+        return currentSentenceHasItemOption;
+    }
+
     public void HintAt(DialogueTrigger trigger) {
         Debug.Log("Hinting at dialogue by " + trigger.name);
         hintUI.Hint(trigger.hintPosition, DIALOGUE_KEY_STR);
     }
     public void ClearHint() {
         hintUI.ClearHint();
+    }
+
+    public void SelectFirstActionBox() {
+        if (firstActionBoxButton != null) {
+            StartCoroutine(UIUtility.SelectButtonLater(firstActionBoxButton));
+        }
+    }
+    public void SelectItemActionBox() {
+        if (itemActionBoxButton != null) {
+            StartCoroutine(UIUtility.SelectButtonLater(itemActionBoxButton));
+        }
     }
  
 }

--- a/Assets/Dialogue/DialogueManager.cs
+++ b/Assets/Dialogue/DialogueManager.cs
@@ -95,7 +95,7 @@ public class DialogueManager : MonoBehaviour
             uiAnimator.SetInteger("World", (int) currentTrigger.world);
         }
 
-        InventoryCanvasSlots.Instance.Show();
+        InventoryCanvasSlots.Instance.Hide();
 
         if (otherDialogueWasActive && clearCurrent) {
             sentences.Clear();
@@ -125,6 +125,14 @@ public class DialogueManager : MonoBehaviour
     // with the DialogueOption holding whatever item was seletced.
     // The item may or may not trigger a specific or useful action/respoonse.
     public void DisplayNextSentence(DialogueOption chosenOption = null, Item item = null) {
+
+        if (chosenOption is OpenInventoryOption) {
+            // Show inventory...
+            InventoryCanvasSlots.Instance.Show();
+            InventoryCanvasSlots.Instance.SelectFirstItemBoxButton();
+            // ...and remain on the current sentence
+            return;
+        }
 
         /* Happens when an inventory item button is pressed outside of a dialogue */
         if (!IsDialogueActive()) return;
@@ -173,6 +181,8 @@ public class DialogueManager : MonoBehaviour
         //while (nextEvents.Count != 0) {
         //    nextEvents.Dequeue().Invoke();
         //}
+
+        InventoryCanvasSlots.Instance.Hide();  // Only shown when OpenInventoryOption is chosen
 
         if (chosenOption != null) {
             foreach (DialogueAction action in chosenOption.onChose) {
@@ -237,6 +247,13 @@ public class DialogueManager : MonoBehaviour
                     shownOptions.Add(availableOption);
                 }
             }
+            bool hasItemOption = availableOptions.Exists(
+                (DialogueOption option) => option is ItemOption || option is OtherItemOption
+            );
+            if (hasItemOption) {
+                Debug.Log("Sentence has an ItemOption");
+                shownOptions.Add(new OpenInventoryOption());
+            }
 
             int n = Mathf.Min(shownOptions.Count, actionBoxes.Count);
             for (int i = 0; i < n; ++i) {
@@ -250,6 +267,8 @@ public class DialogueManager : MonoBehaviour
                 TextMeshProUGUI text = actionBox.text;
                 Image image = actionBox.image;
 
+                
+
                 if (option is ItemOption) {
                     ItemOption itemOption = (ItemOption) option;
                     text.text = Uwu.OptionalUwufy(itemOption.item.name);
@@ -260,8 +279,11 @@ public class DialogueManager : MonoBehaviour
                     image.gameObject.SetActive(false);
                     actionBox.button.interactable = true;
                 }
+                if (option is OpenInventoryOption) {
+                   // actionBox.button.onClick = () => {};
+                }
                 if (i == 0) {
-                    StartCoroutine( UIUtility.SelectButtonLater(actionBox.button));
+                    StartCoroutine(UIUtility.SelectButtonLater(actionBox.button));
                 }
             }
             foreach (Animator uiAnimator in uiAnimators) {

--- a/Assets/Dialogue/DialogueOption.cs
+++ b/Assets/Dialogue/DialogueOption.cs
@@ -1,8 +1,11 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using UnityEngine.UI;
 using UnityEngine.Events;
 using UnityEngine;
+using TMPro;
+
 
 [Serializable]
 public abstract class DialogueOption {
@@ -35,4 +38,8 @@ public class ItemOption : DialogueOption {
 
 public class OtherItemOption : DialogueOption {
     
+}
+
+public class OpenInventoryOption : TextOption {
+    public OpenInventoryOption() : base("Select Item") {}
 }

--- a/Assets/Inventory/InventoryCanvasSlots.cs
+++ b/Assets/Inventory/InventoryCanvasSlots.cs
@@ -29,24 +29,28 @@ public class InventoryCanvasSlots : MonoBehaviour
         Clear();
         canvas.enabled = false;
     }
-    public void SetActionBoxVisibility(bool visible) {
+    private void SetActionBoxesActive(bool active) {
         // not that big of a problem anymore, huh?
         dialogueOptionBoxes.transform.localScale =
-                visible ? new Vector3(1, 1, 1) : new Vector3(0, 0, 0);
+                active ? new Vector3(1, 1, 1) : new Vector3(0, 0, 0);
+        var actionButtons = dialogueOptionBoxes.GetComponentsInChildren<Button>();
+        foreach (Button button in actionButtons) {
+            button.interactable = active;
+        }
     }
     public void ShowItemLoreBox(Item item) {
         if (!Inventory.Instance.HasItem(item)) {
             HideItemLoreBox();
         }
         itemLoreBoxAnimator.SetInteger("World", (int) item.originWorld);
-        SetActionBoxVisibility(false);
+        SetActionBoxesActive(false);
         itemLoreBox.DisplayLore(item);
         itemLoreBox.gameObject.SetActive(true);
         loreVisible = true;
     }
 
     public void HideItemLoreBox() {
-        SetActionBoxVisibility(true);
+        SetActionBoxesActive(true);
         itemLoreBox.gameObject.SetActive(false);
         loreVisible = false;
     }
@@ -61,8 +65,15 @@ public class InventoryCanvasSlots : MonoBehaviour
         HideItemLoreBox();
     }
 
+    private bool CanBeOpenend() {
+        if (DialogueManager.Instance.IsDialogueActive()) {
+            return DialogueManager.Instance.CurrentSentenceHasItemOption();
+        }
+        return true;  // no dialogue active
+    }
+
     private void Update() {
-        if (Input.GetKeyDown(KeyCode.Tab) && !DialogueManager.Instance.IsDialogueActive()) {
+        if (Input.GetKeyDown(KeyCode.Tab) && CanBeOpenend()) {
             if (visible) {
                 Hide();
             } else {
@@ -116,6 +127,11 @@ public class InventoryCanvasSlots : MonoBehaviour
 
             stevecontroller steve = GameObject.FindObjectOfType<stevecontroller>();
             steve.Unlock(INVENTORY_LOCK_TAG);
+
+            if (DialogueManager.Instance.IsDialogueActive()) {
+                SetActionBoxesActive(true);
+                DialogueManager.Instance.SelectItemActionBox();
+            }
     }
 
     private void Clear() {

--- a/Assets/Inventory/InventoryCanvasSlots.cs
+++ b/Assets/Inventory/InventoryCanvasSlots.cs
@@ -90,6 +90,13 @@ public class InventoryCanvasSlots : MonoBehaviour
     public void Show() {
             stevecontroller steve = GameObject.FindObjectOfType<stevecontroller>();
             steve.Lock(INVENTORY_LOCK_TAG);
+
+            foreach (InventorySlot slot in slots) {
+                slot.button.enabled = true;
+                slot.button.Selected = false;
+                slot.button.interactable = true;
+            }
+
             DisplayItems(Inventory.Instance.items);
             visible = true;
             canvas.enabled = true;
@@ -100,9 +107,13 @@ public class InventoryCanvasSlots : MonoBehaviour
             visible = false;
             canvas.enabled = false;
             HideItemLoreBox();
+
             foreach (InventorySlot slot in slots) {
                 slot.button.Selected = false;
+                slot.button.interactable = false;
+                slot.button.enabled = false;
             }
+
             stevecontroller steve = GameObject.FindObjectOfType<stevecontroller>();
             steve.Unlock(INVENTORY_LOCK_TAG);
     }
@@ -149,5 +160,13 @@ public class InventoryCanvasSlots : MonoBehaviour
 
     public bool IsShowing() {
         return canvas.enabled;
+    }
+
+    public void SelectFirstItemBoxButton() {
+        if (firstItemBoxButton == null) {
+            Debug.LogWarning("First item box button of inventory must not be null");
+        } else {
+            StartCoroutine(UIUtility.SelectButtonLater(firstItemBoxButton));
+        }
     }
 }


### PR DESCRIPTION
"Select Item" or pressing `Tab` will open the inventory to allow the
player to choose an item.  The inventory can be closed by pressing `Tab`
again.

Also fixes the 4th actionbutton being assigned the wrong action.

Closes #92
