### PR TITLE
Pausemenu: Keep in front, disable during dialogue

### DIFF
--- a/Assets/Menu/PauseMenu/PauseCanvas.prefab
+++ b/Assets/Menu/PauseMenu/PauseCanvas.prefab
@@ -598,7 +598,7 @@ Canvas:
   m_SortingBucketNormalizedSize: 0
   m_AdditionalShaderChannelsFlag: 25
   m_SortingLayerID: -689500579
-  m_SortingOrder: 0
+  m_SortingOrder: 420
   m_TargetDisplay: 0
 --- !u!114 &8583597184318078651
 MonoBehaviour:
@@ -682,6 +682,7 @@ MonoBehaviour:
   transitionAnimationSpeedFactor: 1
   animationDelay: 0
   hintPosition: {fileID: 0}
+  animateAsElevator: 0
   playerLayer:
     serializedVersion: 2
     m_Bits: 0

--- a/Assets/Menu/PauseMenu/PauseMenu.cs
+++ b/Assets/Menu/PauseMenu/PauseMenu.cs
@@ -23,14 +23,14 @@ public class PauseMenu : MonoBehaviour
     }
 
     void Update(){
-        if(SceneManager.GetActiveScene().name != "MenuScene"){
-            if(Input.GetKeyDown(KeyCode.Escape)){
-                if(paused){
-                    Continue();
-                }
-                else{
-                    Pause();
-                }
+        if (SceneManager.GetActiveScene().name != "MenuScene"
+                && !DialogueManager.Instance.IsDialogueActive()
+                && Input.GetKeyDown(KeyCode.Escape)) {
+
+            if(paused){
+                Continue();
+            } else {
+                Pause();
             }
         }
     }


### PR DESCRIPTION
- Draw PauseMenu in front of all other UI
- Disable PauseMenu when in Dialogues

Fixes #121
